### PR TITLE
Track DOM appearance timing for API fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # api-value-seen
+
+A Firefox extension and Cypress plugin that intercept API requests, records fields from JSON responses, and tracks when those values first appear in the page's DOM.
+
+## Repository Structure
+- `firefox-extension/` – temporary Firefox add-on with popup UI, background script, and content script.
+- `cypress-plugin/` – Cypress plugin for recording API field usage during tests.
+
+## Firefox Extension
+
+1. Open `about:debugging#/runtime/this-firefox` in Firefox.
+2. Click **Load Temporary Add-on...** and choose `firefox-extension/manifest.json`.
+3. Use the extension popup to **Start Recording**, optionally specifying a comma-separated list of domains to monitor (leave blank for all domains) and a timeout in milliseconds (default 5000) to wait for field values to appear in the DOM.
+4. Browse as normal; logs will accumulate across pages until you **Stop Recording**.
+5. Review captured entries and timing details in the popup or click **Download Report** to save them as `api-report.json`.
+
+## Cypress Plugin
+
+1. Copy `cypress-plugin/index.js` into your project's `cypress/support` folder and import it from `cypress/support/e2e.js` (or `cypress/support/index.js` in Cypress <10):
+
+   ```js
+   import '../../path/to/index.js';
+   ```
+
+2. Start recording at the beginning of your test and optionally restrict domains or adjust the timeout (in ms):
+
+   ```js
+   cy.startApiRecording({ domains: ['api.example.com'], timeoutMs: 5000 });
+   ```
+
+3. Run your test actions. When finished, stop recording and save the report:
+
+   ```js
+   cy.stopApiRecording().then((report) => {
+     cy.writeFile('api-report.json', report);
+   });
+   ```
+
+The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds).
+
+## Development
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+(There are currently no external dependencies, but the test confirms the Cypress plugin registers custom commands.)

--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -1,0 +1,123 @@
+let recording = false;
+let domains = [];
+let report = [];
+
+const shouldTrack = (url) =>
+  domains.length === 0 || domains.some((d) => url.includes(d));
+
+let timeoutMs = 5000;
+
+function handleResponse(win, data, url) {
+  const fields = [];
+  function traverse(obj, path = []) {
+    if (obj && typeof obj === 'object') {
+      for (const key in obj) {
+        traverse(obj[key], path.concat(key));
+      }
+    } else {
+      fields.push({
+        path: path.join('.'),
+        value: String(obj),
+        firstSeenMs: null,
+        lastCheckedMs: 0
+      });
+    }
+  }
+  traverse(data);
+
+  const start = win.performance.now();
+  let finished = false;
+
+  function check() {
+    const now = win.performance.now();
+    for (const field of fields) {
+      if (field.firstSeenMs !== null) continue;
+      if (win.document.body.innerText.includes(field.value)) {
+        field.firstSeenMs = now - start;
+        field.lastCheckedMs = field.firstSeenMs;
+      } else {
+        field.lastCheckedMs = now - start;
+      }
+    }
+    if (fields.every(f => f.firstSeenMs !== null)) {
+      finalize();
+      observer.disconnect();
+    }
+  }
+
+  const observer = new win.MutationObserver(check);
+  observer.observe(win.document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+
+  const timeoutId = win.setTimeout(() => {
+    observer.disconnect();
+    check();
+    finalize();
+  }, timeoutMs);
+
+  function finalize() {
+    if (finished) return;
+    finished = true;
+    win.clearTimeout(timeoutId);
+    report.push({ url, fields });
+  }
+
+  check();
+}
+
+Cypress.on('window:before:load', (win) => {
+  const originalFetch = win.fetch;
+  win.fetch = async function (...args) {
+    const response = await originalFetch.apply(this, args);
+    if (recording && shouldTrack(args[0])) {
+      try {
+        const clone = response.clone();
+        const data = await clone.json();
+        handleResponse(win, data, args[0]);
+      } catch (e) {
+        // non JSON response
+      }
+    }
+    return response;
+  };
+
+  const originalOpen = win.XMLHttpRequest.prototype.open;
+  win.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    this._url = url;
+    return originalOpen.call(this, method, url, ...rest);
+  };
+
+  const originalSend = win.XMLHttpRequest.prototype.send;
+  win.XMLHttpRequest.prototype.send = function (...sendArgs) {
+    this.addEventListener('load', function () {
+      if (recording && shouldTrack(this._url)) {
+        try {
+          const data = JSON.parse(this.responseText);
+          handleResponse(win, data, this._url);
+        } catch (e) {
+          // ignore non JSON
+        }
+      }
+    });
+    return originalSend.apply(this, sendArgs);
+  };
+});
+
+Cypress.Commands.add('startApiRecording', (options = {}) => {
+  domains = (options.domains || []).map((d) => d.trim()).filter(Boolean);
+  timeoutMs = options.timeoutMs || 5000;
+  report = [];
+  recording = true;
+});
+
+Cypress.Commands.add('stopApiRecording', () => {
+  recording = false;
+  return cy.wrap(report);
+});
+
+Cypress.Commands.add('getApiReport', () => {
+  return cy.wrap(report);
+});

--- a/firefox-extension/background.js
+++ b/firefox-extension/background.js
@@ -1,0 +1,42 @@
+const state = {
+  recording: false,
+  domains: [],
+  logs: [],
+  timeoutMs: 5000
+};
+
+function shouldTrack(url) {
+  if (state.domains.length === 0) return true;
+  try {
+    const host = new URL(url).hostname;
+    return state.domains.includes(host);
+  } catch (e) {
+    return false;
+  }
+}
+
+browser.runtime.onMessage.addListener((message) => {
+  switch (message.action) {
+    case 'start':
+      state.recording = true;
+      state.domains = message.domains || [];
+      state.timeoutMs = message.timeoutMs || 5000;
+      state.logs = [];
+      return Promise.resolve(state);
+    case 'stop':
+      state.recording = false;
+      return Promise.resolve(state);
+    case 'clear':
+      state.logs = [];
+      return Promise.resolve(state);
+    case 'getState':
+      return Promise.resolve(state);
+    case 'log':
+      if (state.recording && shouldTrack(message.url)) {
+        state.logs.push({ url: message.url, fields: message.fields });
+      }
+      break;
+    default:
+      break;
+  }
+});

--- a/firefox-extension/content.js
+++ b/firefox-extension/content.js
@@ -1,0 +1,100 @@
+(() => {
+  const runtime = typeof browser !== 'undefined' ? browser.runtime : chrome.runtime;
+
+  const originalFetch = window.fetch;
+  window.fetch = async function (...args) {
+    const response = await originalFetch.apply(this, args);
+    try {
+      const clone = response.clone();
+      const data = await clone.json();
+      handleResponse(data, args[0]);
+    } catch (e) {
+      // Response is not JSON or parsing failed
+    }
+    return response;
+  };
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    this._url = url;
+    return originalOpen.call(this, method, url, ...rest);
+  };
+
+  const originalSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.send = function (...args) {
+    this.addEventListener('load', function () {
+      try {
+        const data = JSON.parse(this.responseText);
+        handleResponse(data, this._url);
+      } catch (e) {
+        // Non JSON response
+      }
+    });
+    return originalSend.apply(this, args);
+  };
+
+  function handleResponse(data, url) {
+    runtime.sendMessage({ action: 'getState' }).then(state => {
+      const CHECK_TIMEOUT_MS = state.timeoutMs || 5000;
+
+      const fields = [];
+      function traverse(obj, path = []) {
+        if (typeof obj === 'object' && obj !== null) {
+          for (const key in obj) {
+            traverse(obj[key], path.concat(key));
+          }
+        } else {
+          fields.push({
+            path: path.join('.'),
+            value: String(obj),
+            firstSeenMs: null,
+            lastCheckedMs: 0
+          });
+        }
+      }
+      traverse(data);
+
+      const start = performance.now();
+      let finished = false;
+
+      function check() {
+        const now = performance.now();
+        for (const field of fields) {
+          if (field.firstSeenMs !== null) continue;
+          if (document.body.innerText.includes(field.value)) {
+            field.firstSeenMs = now - start;
+            field.lastCheckedMs = field.firstSeenMs;
+          } else {
+            field.lastCheckedMs = now - start;
+          }
+        }
+        if (fields.every(f => f.firstSeenMs !== null)) {
+          finalize();
+          observer.disconnect();
+        }
+      }
+
+      const observer = new MutationObserver(check);
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        characterData: true
+      });
+
+      const timeoutId = setTimeout(() => {
+        observer.disconnect();
+        check();
+        finalize();
+      }, CHECK_TIMEOUT_MS);
+
+      function finalize() {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timeoutId);
+        runtime.sendMessage({ action: 'log', url, fields });
+      }
+
+      check();
+    });
+  }
+})();

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 2,
+  "name": "API Value Tracker",
+  "version": "1.0",
+  "description": "Tracks API responses and checks if values appear in the DOM.",
+  "permissions": ["<all_urls>", "storage"],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_title": "API Value Tracker"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/firefox-extension/popup.html
+++ b/firefox-extension/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>API Tracker</title>
+  <style>
+    body { font-family: sans-serif; min-width: 300px; }
+    pre { max-height: 200px; overflow: auto; background: #f0f0f0; padding: 5px; }
+    input { width: 100%; }
+    button { margin-top: 5px; }
+  </style>
+</head>
+<body>
+  <h3>API Tracker</h3>
+  <label>Domains (comma separated):<br/>
+    <input id="domains" type="text" placeholder="example.com, api.example.com" />
+  </label>
+  <label>Timeout (ms):<br/>
+    <input id="timeout" type="number" value="5000" />
+  </label>
+  <div>
+    <button id="start">Start Recording</button>
+    <button id="stop">Stop Recording</button>
+    <button id="clear">Clear Logs</button>
+  </div>
+  <div>
+    <button id="download">Download Report</button>
+  </div>
+  <pre id="output"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/firefox-extension/popup.js
+++ b/firefox-extension/popup.js
@@ -1,0 +1,52 @@
+const runtime = typeof browser !== 'undefined' ? browser.runtime : chrome.runtime;
+
+async function render() {
+  const state = await runtime.sendMessage({ action: 'getState' });
+  document.getElementById('domains').value = state.domains.join(', ');
+  document.getElementById('timeout').value = state.timeoutMs || 5000;
+  document.getElementById('start').disabled = state.recording;
+  document.getElementById('stop').disabled = !state.recording;
+  const formatted = state.logs
+    .map(entry => {
+      const lines = [`URL: ${entry.url}`];
+      entry.fields.forEach(f => {
+        lines.push(`  ${f.path}: ${f.value} (firstSeenMs: ${f.firstSeenMs ?? 'n/a'}, lastCheckedMs: ${f.lastCheckedMs})`);
+      });
+      return lines.join('\n');
+    })
+    .join('\n\n');
+  document.getElementById('output').textContent = formatted;
+}
+
+document.getElementById('start').addEventListener('click', async () => {
+  const domains = document.getElementById('domains').value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const timeoutMs = parseInt(document.getElementById('timeout').value, 10);
+  await runtime.sendMessage({ action: 'start', domains, timeoutMs });
+  render();
+});
+
+document.getElementById('stop').addEventListener('click', async () => {
+  await runtime.sendMessage({ action: 'stop' });
+  render();
+});
+
+document.getElementById('clear').addEventListener('click', async () => {
+  await runtime.sendMessage({ action: 'clear' });
+  render();
+});
+
+document.getElementById('download').addEventListener('click', async () => {
+  const state = await runtime.sendMessage({ action: 'getState' });
+  const blob = new Blob([JSON.stringify(state.logs, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'api-report.json';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+document.addEventListener('DOMContentLoaded', render);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "api-value-seen",
+  "version": "0.1.0",
+  "description": "Firefox extension and Cypress plugin to track API responses and DOM usage",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// stub global Cypress object used by the plugin
+const added = [];
+global.Cypress = {
+  on: () => {},
+  Commands: {
+    add: (name) => added.push(name)
+  }
+};
+
+test('cypress plugin registers custom commands', async () => {
+  await import('../cypress-plugin/index.js');
+  assert.deepEqual(added.sort(), ['getApiReport', 'startApiRecording', 'stopApiRecording']);
+});


### PR DESCRIPTION
## Summary
- replace one-second polling with a MutationObserver to watch DOM changes and record when each API field value first appears
- store `firstSeenMs`/`lastCheckedMs` for every field in background logs and surface timing details in the popup
- allow the Cypress plugin to capture appearance timing with a configurable timeout
- add a popup field to configure the DOM-appearance timeout for the Firefox extension

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d970d4348320b34cd1d8ef8ec847