### PR TITLE
Add tests for API recording timing and npm metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 api-value-seen contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -5,5 +5,22 @@
   "type": "module",
   "scripts": {
     "test": "node --test"
-  }
+  },
+  "license": "MIT",
+  "main": "cypress-plugin/index.js",
+  "files": [
+    "cypress-plugin",
+    "firefox-extension"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/example/api-value-seen.git"
+  },
+  "keywords": [
+    "cypress",
+    "plugin",
+    "api",
+    "dom"
+  ],
+  "author": ""
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,16 +1,115 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
 
-// stub global Cypress object used by the plugin
-const added = [];
+const commands = {};
+let windowHandler;
+
 global.Cypress = {
-  on: () => {},
+  on: (event, fn) => {
+    if (event === 'window:before:load') {
+      windowHandler = fn;
+    }
+  },
   Commands: {
-    add: (name) => added.push(name)
+    add: (name, fn) => {
+      commands[name] = fn;
+    }
   }
 };
 
-test('cypress plugin registers custom commands', async () => {
-  await import('../cypress-plugin/index.js');
-  assert.deepEqual(added.sort(), ['getApiReport', 'startApiRecording', 'stopApiRecording']);
+global.cy = { wrap: (x) => x };
+
+await import('../cypress-plugin/index.js');
+
+test('cypress plugin registers custom commands', () => {
+  assert.deepEqual(Object.keys(commands).sort(), ['getApiReport', 'startApiRecording', 'stopApiRecording']);
+});
+
+function createWin(responseData) {
+  const body = { innerText: '' };
+  let observerCallback;
+  class FakeMutationObserver {
+    constructor(cb) {
+      observerCallback = cb;
+    }
+    observe() {}
+    disconnect() {}
+  }
+
+  const win = {
+    document: { body },
+    MutationObserver: FakeMutationObserver,
+    performance: { now: () => performance.now() },
+    setTimeout,
+    clearTimeout,
+    fetch: async () => new ResponseStub(responseData),
+    XMLHttpRequest: function () {}
+  };
+
+  win.XMLHttpRequest.prototype = {
+    open() {},
+    send() {},
+    addEventListener() {}
+  };
+
+  win.triggerMutation = () => observerCallback && observerCallback();
+
+  return win;
+}
+
+class ResponseStub {
+  constructor(data) {
+    this.data = data;
+  }
+  clone() {
+    return new ResponseStub(this.data);
+  }
+  async json() {
+    return this.data;
+  }
+}
+
+test('records firstSeenMs when value appears in DOM', { concurrency: false }, async () => {
+  const win = createWin({ foo: 'bar' });
+  windowHandler(win);
+
+  commands.startApiRecording({ timeoutMs: 100 });
+
+  await win.fetch('https://example.com/api');
+
+  win.document.body.innerText = 'bar';
+  win.triggerMutation();
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  const report = commands.stopApiRecording();
+  assert.equal(report.length, 1);
+  const field = report[0].fields[0];
+  assert.equal(field.path, 'foo');
+  assert.equal(field.value, 'bar');
+  assert.ok(field.firstSeenMs > 0);
+  assert.equal(field.firstSeenMs, field.lastCheckedMs);
+  assert.ok(field.firstSeenMs < 100);
+  assert.deepEqual(commands.getApiReport(), report);
+});
+
+test('uses timeout when value never appears', { concurrency: false }, async () => {
+  const win = createWin({ missing: 'value' });
+  windowHandler(win);
+
+  commands.startApiRecording({ timeoutMs: 30 });
+
+  await win.fetch('https://example.com/api');
+
+  await new Promise((r) => setTimeout(r, 60));
+
+  const report = commands.stopApiRecording();
+  assert.equal(report.length, 1);
+  const field = report[0].fields[0];
+  assert.equal(field.path, 'missing');
+  assert.equal(field.value, 'value');
+  assert.equal(field.firstSeenMs, null);
+  assert.ok(field.lastCheckedMs >= 30);
+  assert.ok(field.lastCheckedMs < 100);
 });


### PR DESCRIPTION
## Summary
- add tests covering API recording report timing and custom commands
- include MIT license and package metadata to prepare for npm publishing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951f5b9414832090240d17e2d883d5