### PR TITLE
test: verify report reset between recordings

### DIFF
--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -113,3 +113,27 @@ test('uses timeout when value never appears', { concurrency: false }, async () =
   assert.ok(field.lastCheckedMs >= 30);
   assert.ok(field.lastCheckedMs < 100);
 });
+
+test('resets report between recordings', { concurrency: false }, async () => {
+  const responseData = { run: 'first' };
+  const win = createWin(responseData);
+  windowHandler(win);
+
+  commands.startApiRecording({ timeoutMs: 10 });
+  await win.fetch('https://example.com/api1');
+  await new Promise((r) => setTimeout(r, 20));
+  commands.stopApiRecording();
+
+  responseData.run = 'second';
+
+  commands.startApiRecording({ timeoutMs: 10 });
+  await win.fetch('https://example.com/api2');
+  await new Promise((r) => setTimeout(r, 20));
+  const report = commands.stopApiRecording();
+
+  assert.equal(report.length, 1);
+  const field = report[0].fields[0];
+  assert.equal(field.path, 'run');
+  assert.equal(field.value, 'second');
+  assert.deepEqual(commands.getApiReport(), report);
+});


### PR DESCRIPTION
## Summary
- add coverage ensuring `startApiRecording` clears previous results before new recording
- confirm subsequent report only includes data from the second recording

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689599606370832091c8a98ce5d412a3