### PR TITLE
Add Cypress tests for API recording plugin

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    supportFile: false
+  }
+});

--- a/cypress/e2e/api_recording.cy.js
+++ b/cypress/e2e/api_recording.cy.js
@@ -1,0 +1,50 @@
+import '../../cypress-plugin';
+
+describe('API recording plugin', () => {
+  beforeEach(() => {
+    cy.startApiRecording({ timeoutMs: 500 });
+    cy.intercept('/api/test', { body: { foo: 'bar' } }).as('api');
+  });
+
+  it('records when value appears in DOM', () => {
+    cy.intercept('/test-page', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/test').then(r => r.json()).then(d => {
+          const el = document.createElement('div');
+          el.id = 'result';
+          el.textContent = d.foo;
+          document.body.appendChild(el);
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/test-page');
+    cy.wait('@api');
+    cy.stopApiRecording().then(report => {
+      expect(report[0].fields[0])
+        .to.have.property('firstSeenMs')
+        .and.be.lt(500);
+    });
+  });
+
+  it('handles value not appearing in DOM', () => {
+    cy.intercept('/test-page', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/test').then(r => r.json()).then(d => {
+          // value not inserted into DOM
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/test-page');
+    cy.wait('@api');
+    cy.wait(600);
+    cy.stopApiRecording().then(report => {
+      const field = report[0].fields[0];
+      expect(field).to.have.property('firstSeenMs', null);
+      expect(field.lastCheckedMs).to.be.gte(500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- configure Cypress for E2E testing
- add tests that verify API value tracking when DOM contains or omits fetched value

## Testing
- `npm test`
- `npx cypress run` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959a86009883209bc582808e5380dd