### PR TITLE
feat: package Cypress plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
 
 ## Cypress Plugin
 
-1. Copy `cypress-plugin/index.js` into your project's `cypress/support` folder and import it from `cypress/support/e2e.js` (or `cypress/support/index.js` in Cypress <10):
+1. Install the plugin and load it from your Cypress support file:
+
+   ```bash
+   npm install cypress-api-value-seen
+   ```
 
    ```js
-   import '../../path/to/index.js';
+   import 'cypress-api-value-seen';
    ```
 
 2. Start recording at the beginning of your test and optionally restrict domains or adjust the timeout (in ms):

--- a/cypress-plugin/package.json
+++ b/cypress-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cypress-api-value-seen",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "files": [
+    "index.js"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "api-value-seen",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api-value-seen",
+      "version": "0.1.0",
+      "dependencies": {
+        "cypress-api-value-seen": "file:cypress-plugin"
+      }
+    },
+    "cypress-plugin": {
+      "name": "cypress-api-value-seen",
+      "version": "0.1.0"
+    },
+    "node_modules/cypress-api-value-seen": {
+      "resolved": "cypress-plugin",
+      "link": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "cypress-api-value-seen": "file:cypress-plugin"
   }
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -20,7 +20,7 @@ global.Cypress = {
 
 global.cy = { wrap: (x) => x };
 
-await import('../cypress-plugin/index.js');
+await import('cypress-api-value-seen');
 
 test('cypress plugin registers custom commands', () => {
   assert.deepEqual(Object.keys(commands).sort(), ['getApiReport', 'startApiRecording', 'stopApiRecording']);


### PR DESCRIPTION
## Summary
- package Cypress plugin with its own `package.json`
- depend on plugin via local file dependency
- document `npm install cypress-api-value-seen` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ae68e240832096d38ddb11a46f4a