### PR TITLE
refactor: share api value tracker

### DIFF
--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -1,109 +1,19 @@
+import { interceptResponses, collectFields, observeFields } from '../shared/apiValueTracker.js';
+
 let recording = false;
 let domains = [];
 let report = [];
+let timeoutMs = 5000;
 
 const shouldTrack = (url) =>
   domains.length === 0 || domains.some((d) => url.includes(d));
 
-let timeoutMs = 5000;
-
-function handleResponse(win, data, url) {
-  const fields = [];
-  function traverse(obj, path = []) {
-    if (obj && typeof obj === 'object') {
-      for (const key in obj) {
-        traverse(obj[key], path.concat(key));
-      }
-    } else {
-      fields.push({
-        path: path.join('.'),
-        value: String(obj),
-        firstSeenMs: null,
-        lastCheckedMs: 0
-      });
-    }
-  }
-  traverse(data);
-
-  const start = win.performance.now();
-  let finished = false;
-
-  function check() {
-    const now = win.performance.now();
-    for (const field of fields) {
-      if (field.firstSeenMs !== null) continue;
-      if (win.document.body.innerText.includes(field.value)) {
-        field.firstSeenMs = now - start;
-        field.lastCheckedMs = field.firstSeenMs;
-      } else {
-        field.lastCheckedMs = now - start;
-      }
-    }
-    if (fields.every(f => f.firstSeenMs !== null)) {
-      finalize();
-      observer.disconnect();
-    }
-  }
-
-  const observer = new win.MutationObserver(check);
-  observer.observe(win.document.body, {
-    childList: true,
-    subtree: true,
-    characterData: true
-  });
-
-  const timeoutId = win.setTimeout(() => {
-    observer.disconnect();
-    check();
-    finalize();
-  }, timeoutMs);
-
-  function finalize() {
-    if (finished) return;
-    finished = true;
-    win.clearTimeout(timeoutId);
-    report.push({ url, fields });
-  }
-
-  check();
-}
-
 Cypress.on('window:before:load', (win) => {
-  const originalFetch = win.fetch;
-  win.fetch = async function (...args) {
-    const response = await originalFetch.apply(this, args);
-    if (recording && shouldTrack(args[0])) {
-      try {
-        const clone = response.clone();
-        const data = await clone.json();
-        handleResponse(win, data, args[0]);
-      } catch (e) {
-        // non JSON response
-      }
-    }
-    return response;
-  };
-
-  const originalOpen = win.XMLHttpRequest.prototype.open;
-  win.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
-    this._url = url;
-    return originalOpen.call(this, method, url, ...rest);
-  };
-
-  const originalSend = win.XMLHttpRequest.prototype.send;
-  win.XMLHttpRequest.prototype.send = function (...sendArgs) {
-    this.addEventListener('load', function () {
-      if (recording && shouldTrack(this._url)) {
-        try {
-          const data = JSON.parse(this.responseText);
-          handleResponse(win, data, this._url);
-        } catch (e) {
-          // ignore non JSON
-        }
-      }
-    });
-    return originalSend.apply(this, sendArgs);
-  };
+  interceptResponses(win, (data, url) => {
+    if (!recording || !shouldTrack(url)) return;
+    const fields = collectFields(data);
+    observeFields(win, fields, url, (result) => report.push(result), timeoutMs);
+  });
 });
 
 Cypress.Commands.add('startApiRecording', (options = {}) => {

--- a/firefox-extension/content.js
+++ b/firefox-extension/content.js
@@ -1,100 +1,24 @@
+import { interceptResponses, collectFields, observeFields } from '../shared/apiValueTracker.js';
+
 (() => {
   const runtime = typeof browser !== 'undefined' ? browser.runtime : chrome.runtime;
 
-  const originalFetch = window.fetch;
-  window.fetch = async function (...args) {
-    const response = await originalFetch.apply(this, args);
-    try {
-      const clone = response.clone();
-      const data = await clone.json();
-      handleResponse(data, args[0]);
-    } catch (e) {
-      // Response is not JSON or parsing failed
-    }
-    return response;
-  };
-
-  const originalOpen = XMLHttpRequest.prototype.open;
-  XMLHttpRequest.prototype.open = function (method, url, ...rest) {
-    this._url = url;
-    return originalOpen.call(this, method, url, ...rest);
-  };
-
-  const originalSend = XMLHttpRequest.prototype.send;
-  XMLHttpRequest.prototype.send = function (...args) {
-    this.addEventListener('load', function () {
-      try {
-        const data = JSON.parse(this.responseText);
-        handleResponse(data, this._url);
-      } catch (e) {
-        // Non JSON response
-      }
-    });
-    return originalSend.apply(this, args);
-  };
-
-  function handleResponse(data, url) {
+  interceptResponses(window, (data, url) => {
     runtime.sendMessage({ action: 'getState' }).then(state => {
-      const CHECK_TIMEOUT_MS = state.timeoutMs || 5000;
-
-      const fields = [];
-      function traverse(obj, path = []) {
-        if (typeof obj === 'object' && obj !== null) {
-          for (const key in obj) {
-            traverse(obj[key], path.concat(key));
-          }
-        } else {
-          fields.push({
-            path: path.join('.'),
-            value: String(obj),
-            firstSeenMs: null,
-            lastCheckedMs: 0
-          });
+      const timeoutMs = state.timeoutMs || 5000;
+      if (!state.recording) return;
+      if (state.domains && state.domains.length) {
+        try {
+          const host = new URL(url).hostname;
+          if (!state.domains.includes(host)) return;
+        } catch (e) {
+          return;
         }
       }
-      traverse(data);
-
-      const start = performance.now();
-      let finished = false;
-
-      function check() {
-        const now = performance.now();
-        for (const field of fields) {
-          if (field.firstSeenMs !== null) continue;
-          if (document.body.innerText.includes(field.value)) {
-            field.firstSeenMs = now - start;
-            field.lastCheckedMs = field.firstSeenMs;
-          } else {
-            field.lastCheckedMs = now - start;
-          }
-        }
-        if (fields.every(f => f.firstSeenMs !== null)) {
-          finalize();
-          observer.disconnect();
-        }
-      }
-
-      const observer = new MutationObserver(check);
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-        characterData: true
-      });
-
-      const timeoutId = setTimeout(() => {
-        observer.disconnect();
-        check();
-        finalize();
-      }, CHECK_TIMEOUT_MS);
-
-      function finalize() {
-        if (finished) return;
-        finished = true;
-        clearTimeout(timeoutId);
+      const fields = collectFields(data);
+      observeFields(window, fields, url, ({ url, fields }) => {
         runtime.sendMessage({ action: 'log', url, fields });
-      }
-
-      check();
+      }, timeoutMs);
     });
-  }
+  });
 })();

--- a/shared/apiValueTracker.js
+++ b/shared/apiValueTracker.js
@@ -1,0 +1,93 @@
+export function interceptResponses(win, handler) {
+  const originalFetch = win.fetch;
+  win.fetch = async function (...args) {
+    const response = await originalFetch.apply(this, args);
+    try {
+      const clone = response.clone();
+      const data = await clone.json();
+      await handler(data, args[0]);
+    } catch (e) {
+      // non JSON response
+    }
+    return response;
+  };
+
+  const originalOpen = win.XMLHttpRequest.prototype.open;
+  win.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    this._url = url;
+    return originalOpen.call(this, method, url, ...rest);
+  };
+
+  const originalSend = win.XMLHttpRequest.prototype.send;
+  win.XMLHttpRequest.prototype.send = function (...sendArgs) {
+    this.addEventListener('load', function () {
+      try {
+        const data = JSON.parse(this.responseText);
+        handler(data, this._url);
+      } catch (e) {
+        // ignore non JSON
+      }
+    });
+    return originalSend.apply(this, sendArgs);
+  };
+}
+
+export function collectFields(data, path = [], fields = []) {
+  if (data && typeof data === 'object') {
+    for (const key in data) {
+      collectFields(data[key], path.concat(key), fields);
+    }
+  } else {
+    fields.push({
+      path: path.join('.'),
+      value: String(data),
+      firstSeenMs: null,
+      lastCheckedMs: 0
+    });
+  }
+  return fields;
+}
+
+export function observeFields(win, fields, url, log, timeoutMs = 5000) {
+  const start = win.performance.now();
+  let finished = false;
+
+  function check() {
+    const now = win.performance.now();
+    for (const field of fields) {
+      if (field.firstSeenMs !== null) continue;
+      if (win.document.body.innerText.includes(field.value)) {
+        field.firstSeenMs = now - start;
+        field.lastCheckedMs = field.firstSeenMs;
+      } else {
+        field.lastCheckedMs = now - start;
+      }
+    }
+    if (fields.every(f => f.firstSeenMs !== null)) {
+      finalize();
+      observer.disconnect();
+    }
+  }
+
+  const observer = new win.MutationObserver(check);
+  observer.observe(win.document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+
+  const timeoutId = win.setTimeout(() => {
+    observer.disconnect();
+    check();
+    finalize();
+  }, timeoutMs);
+
+  function finalize() {
+    if (finished) return;
+    finished = true;
+    win.clearTimeout(timeoutId);
+    log({ url, fields });
+  }
+
+  check();
+}

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+
+function createWindow(responseData) {
+  let observerCallback;
+  class FakeMutationObserver {
+    constructor(cb) {
+      observerCallback = cb;
+    }
+    observe() {}
+    disconnect() {}
+  }
+
+  const body = { innerText: '' };
+  const win = {
+    document: { body },
+    MutationObserver: FakeMutationObserver,
+    performance: { now: () => performance.now() },
+    setTimeout,
+    clearTimeout,
+    fetch: async () => new ResponseStub(responseData),
+    XMLHttpRequest: function () {}
+  };
+  win.XMLHttpRequest.prototype = {
+    open() {},
+    send() {},
+    addEventListener() {}
+  };
+  win.triggerMutation = () => observerCallback && observerCallback();
+  return win;
+}
+
+class ResponseStub {
+  constructor(data) {
+    this.data = data;
+  }
+  clone() {
+    return new ResponseStub(this.data);
+  }
+  async json() {
+    return this.data;
+  }
+}
+
+test('content script logs values', { concurrency: false }, async () => {
+  const logs = [];
+  const state = { recording: true, domains: [], timeoutMs: 50 };
+  global.browser = {
+    runtime: {
+      sendMessage: (msg) => {
+        if (msg.action === 'getState') return Promise.resolve(state);
+        if (msg.action === 'log') { logs.push(msg); return Promise.resolve(); }
+        return Promise.resolve();
+      }
+    }
+  };
+
+  const win = createWindow({ foo: 'bar' });
+  global.window = win;
+  global.XMLHttpRequest = win.XMLHttpRequest;
+
+  await import('../firefox-extension/content.js');
+
+  await win.fetch('https://example.com/api');
+  win.document.body.innerText = 'bar';
+  win.triggerMutation();
+
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(logs.length, 1);
+  const field = logs[0].fields[0];
+  assert.equal(field.path, 'foo');
+  assert.equal(field.value, 'bar');
+  assert.ok(field.firstSeenMs > 0);
+
+  delete global.browser;
+  delete global.window;
+  delete global.XMLHttpRequest;
+});

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -20,7 +20,7 @@ global.Cypress = {
 
 global.cy = { wrap: (x) => x };
 
-await import('cypress-api-value-seen');
+await import('../cypress-plugin/index.js');
 
 test('cypress plugin registers custom commands', () => {
   assert.deepEqual(Object.keys(commands).sort(), ['getApiReport', 'startApiRecording', 'stopApiRecording']);

--- a/test/shared.test.js
+++ b/test/shared.test.js
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { collectFields, observeFields } from '../shared/apiValueTracker.js';
+
+test('collectFields flattens objects', () => {
+  const fields = collectFields({ a: { b: 1 }, c: 'd' });
+  assert.deepEqual(fields, [
+    { path: 'a.b', value: '1', firstSeenMs: null, lastCheckedMs: 0 },
+    { path: 'c', value: 'd', firstSeenMs: null, lastCheckedMs: 0 }
+  ]);
+});
+
+test('observeFields records firstSeenMs', { concurrency: false }, async () => {
+  let observerCallback;
+  class FakeMutationObserver {
+    constructor(cb) {
+      observerCallback = cb;
+    }
+    observe() {}
+    disconnect() {}
+  }
+
+  const body = { innerText: '' };
+  const win = {
+    document: { body },
+    MutationObserver: FakeMutationObserver,
+    performance: { now: () => performance.now() },
+    setTimeout,
+    clearTimeout
+  };
+
+  const fields = collectFields({ foo: 'bar' });
+  let logged;
+  observeFields(win, fields, 'url', (result) => { logged = result; }, 50);
+
+  body.innerText = 'bar';
+  observerCallback();
+
+  await new Promise((r) => setTimeout(r, 0));
+  const field = logged.fields[0];
+  assert.equal(logged.url, 'url');
+  assert.equal(field.path, 'foo');
+  assert.equal(field.value, 'bar');
+  assert.ok(field.firstSeenMs > 0);
+  assert.equal(field.firstSeenMs, field.lastCheckedMs);
+});


### PR DESCRIPTION
## Summary
- add shared apiValueTracker helpers for response interception, field extraction, and DOM observation
- refactor Cypress plugin and Firefox extension to use shared tracker
- expand test suite for shared helpers and extension integration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b018e060832084678e39aab0054c