### PR TITLE
test: cover multi-page API tracking

### DIFF
--- a/cypress/e2e/multi_page.cy.js
+++ b/cypress/e2e/multi_page.cy.js
@@ -1,0 +1,51 @@
+import '../../cypress-plugin';
+
+describe('API recording across pages', () => {
+  it('captures values from multiple pages', () => {
+    cy.startApiRecording({ timeoutMs: 500 });
+
+    cy.intercept('/api/first', { body: { alpha: 'one' } }).as('api1');
+    cy.intercept('/api/second', { body: { beta: 'two' } }).as('api2');
+
+    cy.intercept('/page-one', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/first').then(r => r.json()).then(d => {
+          const el = document.createElement('div');
+          el.id = 'alpha';
+          el.textContent = d.alpha;
+          document.body.appendChild(el);
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.intercept('/page-two', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/second').then(r => r.json()).then(d => {
+          const el = document.createElement('div');
+          el.id = 'beta';
+          el.textContent = d.beta;
+          document.body.appendChild(el);
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/page-one');
+    cy.wait('@api1');
+    cy.get('#alpha').should('have.text', 'one');
+
+    cy.visit('/page-two');
+    cy.wait('@api2');
+    cy.get('#beta').should('have.text', 'two');
+
+    cy.stopApiRecording().then((report) => {
+      expect(report).to.have.length(2);
+      const first = report.find(r => r.url.includes('/api/first'));
+      const second = report.find(r => r.url.includes('/api/second'));
+      expect(first.fields[0].firstSeenMs).to.be.a('number');
+      expect(second.fields[0].firstSeenMs).to.be.a('number');
+    });
+  });
+});
+

--- a/shared/apiValueTracker.js
+++ b/shared/apiValueTracker.js
@@ -86,6 +86,11 @@ export function observeFields(win, fields, url, log, timeoutMs = 5000) {
     if (finished) return;
     finished = true;
     win.clearTimeout(timeoutId);
+    for (const field of fields) {
+      if (field.firstSeenMs === null) {
+        field.lastCheckedMs = Math.max(field.lastCheckedMs, timeoutMs);
+      }
+    }
     log({ url, fields });
   }
 


### PR DESCRIPTION
## Summary
- add e2e test that visits multiple pages and checks API values are recorded
- ensure tracker sets `lastCheckedMs` to at least the timeout for unseen values

## Testing
- `npm test`
- `npx cypress run` *(fails: Cypress executable not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a70187bc5c83209fb9af6e0d276903