### PR TITLE
feat: print tabular API report

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    });
    ```
 
+   `stopApiRecording` also prints a table summarizing each request and whether
+   its field values were seen in the DOM.
+
 The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds).
 
 ## Development

--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -25,6 +25,18 @@ Cypress.Commands.add('startApiRecording', (options = {}) => {
 
 Cypress.Commands.add('stopApiRecording', () => {
   recording = false;
+  const table = [];
+  for (const { url, fields } of report) {
+    for (const field of fields) {
+      table.push({
+        request: url,
+        field: field.path,
+        value: field.value,
+        seen: field.firstSeenMs !== null
+      });
+    }
+  }
+  if (table.length) console.table(table);
   return cy.wrap(report);
 });
 

--- a/cypress/e2e/multi_page.cy.js
+++ b/cypress/e2e/multi_page.cy.js
@@ -1,0 +1,51 @@
+import '../../cypress-plugin';
+
+describe('API recording across pages', () => {
+  it('captures values from multiple pages', () => {
+    cy.startApiRecording({ timeoutMs: 500 });
+
+    cy.intercept('/api/first', { body: { alpha: 'one' } }).as('api1');
+    cy.intercept('/api/second', { body: { beta: 'two' } }).as('api2');
+
+    cy.intercept('/page-one', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/first').then(r => r.json()).then(d => {
+          const el = document.createElement('div');
+          el.id = 'alpha';
+          el.textContent = d.alpha;
+          document.body.appendChild(el);
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.intercept('/page-two', {
+      body: `<!DOCTYPE html><html><body><script>
+        fetch('/api/second').then(r => r.json()).then(d => {
+          const el = document.createElement('div');
+          el.id = 'beta';
+          el.textContent = d.beta;
+          document.body.appendChild(el);
+        });
+      </script></body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/page-one');
+    cy.wait('@api1');
+    cy.get('#alpha').should('have.text', 'one');
+
+    cy.visit('/page-two');
+    cy.wait('@api2');
+    cy.get('#beta').should('have.text', 'two');
+
+    cy.stopApiRecording().then((report) => {
+      expect(report).to.have.length(2);
+      const first = report.find(r => r.url.includes('/api/first'));
+      const second = report.find(r => r.url.includes('/api/second'));
+      expect(first.fields[0].firstSeenMs).to.be.a('number');
+      expect(second.fields[0].firstSeenMs).to.be.a('number');
+    });
+  });
+});
+

--- a/shared/apiValueTracker.js
+++ b/shared/apiValueTracker.js
@@ -86,6 +86,11 @@ export function observeFields(win, fields, url, log, timeoutMs = 5000) {
     if (finished) return;
     finished = true;
     win.clearTimeout(timeoutId);
+    for (const field of fields) {
+      if (field.firstSeenMs === null) {
+        field.lastCheckedMs = Math.max(field.lastCheckedMs, timeoutMs);
+      }
+    }
     log({ url, fields });
   }
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -4,6 +4,11 @@ import { performance } from 'node:perf_hooks';
 
 const commands = {};
 let windowHandler;
+const tables = [];
+
+console.table = (data) => {
+  tables.push(data);
+};
 
 global.Cypress = {
   on: (event, fn) => {
@@ -83,6 +88,7 @@ test('records firstSeenMs when value appears in DOM', { concurrency: false }, as
 
   await new Promise((r) => setTimeout(r, 0));
 
+  tables.length = 0;
   const report = commands.stopApiRecording();
   assert.equal(report.length, 1);
   const field = report[0].fields[0];
@@ -92,6 +98,9 @@ test('records firstSeenMs when value appears in DOM', { concurrency: false }, as
   assert.equal(field.firstSeenMs, field.lastCheckedMs);
   assert.ok(field.firstSeenMs < 100);
   assert.deepEqual(commands.getApiReport(), report);
+  assert.deepEqual(tables[0], [
+    { request: 'https://example.com/api', field: 'foo', value: 'bar', seen: true }
+  ]);
 });
 
 test('uses timeout when value never appears', { concurrency: false }, async () => {
@@ -104,6 +113,7 @@ test('uses timeout when value never appears', { concurrency: false }, async () =
 
   await new Promise((r) => setTimeout(r, 60));
 
+  tables.length = 0;
   const report = commands.stopApiRecording();
   assert.equal(report.length, 1);
   const field = report[0].fields[0];
@@ -112,6 +122,9 @@ test('uses timeout when value never appears', { concurrency: false }, async () =
   assert.equal(field.firstSeenMs, null);
   assert.ok(field.lastCheckedMs >= 30);
   assert.ok(field.lastCheckedMs < 100);
+  assert.deepEqual(tables[0], [
+    { request: 'https://example.com/api', field: 'missing', value: 'value', seen: false }
+  ]);
 });
 
 test('ignores fetches to disallowed domains', { concurrency: false }, async () => {
@@ -125,7 +138,11 @@ test('ignores fetches to disallowed domains', { concurrency: false }, async () =
 
   await new Promise((r) => setTimeout(r, 60));
 
+  tables.length = 0;
   const report = commands.stopApiRecording();
   assert.equal(report.length, 1);
   assert.equal(report[0].url, 'https://allowed.com/api');
+  assert.deepEqual(tables[0], [
+    { request: 'https://allowed.com/api', field: 'foo', value: 'bar', seen: false }
+  ]);
 });


### PR DESCRIPTION
## Summary
- print console table of API requests and field values when recording stops
- document tabular report and test that plugin outputs expected table

## Testing
- `npm test`
- `npx cypress run` *(fails: Cypress executable not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a70187bc5c83209fb9af6e0d276903