### PR TITLE
Log API values in Cypress and expose report task

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,28 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    cy.stopApiRecording().then((report) => {
      cy.writeFile('api-report.json', report);
    });
-   ```
+  ```
 
-   `stopApiRecording` also prints a table summarizing each request and whether
-   its field values were seen in the DOM.
+   `stopApiRecording` logs a table summarizing each request and whether its
+   field values were seen in the DOM. When running `cypress run`, you can
+   register a task to print the same table from the Node process:
+
+   ```js
+   // cypress.config.js
+   import { getApiReportTask } from 'cypress-api-value-seen';
+   export default defineConfig({
+     e2e: {
+       setupNodeEvents(on) {
+         on('task', { getApiReport: getApiReportTask });
+       }
+     }
+   });
+
+   // support or spec file
+   after(() => {
+     cy.getApiReport().then((report) => cy.task('getApiReport', report));
+   });
+   ```
 
 The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds).
 


### PR DESCRIPTION
## Summary
- Log API values from `stopApiRecording` using `Cypress.log`
- Expose `getApiReportTask` for fetching/logging API report via `cy.task`
- Document optional Node-side logging and update tests

## Testing
- `npm test`
- `npx cypress run` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a730bfc9c88320988586a987a3a19a