### PR TITLE
Report unseen API values and expand e2e demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,30 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    cy.stopApiRecording().then((report) => {
      cy.writeFile('api-report.json', report);
    });
+  ```
+
+   `stopApiRecording` logs a table of any API field values that never
+   appeared in the DOM. When running `cypress run`, you can register a task
+   to print the same table from the Node process:
+
+   ```js
+   // cypress.config.js
+   import { getApiReportTask } from 'cypress-api-value-seen';
+   export default defineConfig({
+     e2e: {
+       setupNodeEvents(on) {
+         on('task', { getApiReport: getApiReportTask });
+       }
+     }
+   });
+
+   // support or spec file
+   after(() => {
+     cy.getApiReport().then((report) => cy.task('getApiReport', report));
+   });
    ```
 
-   `stopApiRecording` also prints a table summarizing each request and whether
-   its field values were seen in the DOM.
-
-The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds).
+The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds). Only unseen values are included in the final report and logs.
 
 ## Development
 

--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -8,6 +8,29 @@ let timeoutMs = 5000;
 const shouldTrack = (url) =>
   domains.length === 0 || domains.some((d) => url.includes(d));
 
+const unseenOnly = (data = report) =>
+  data
+    .map(({ url, fields }) => ({
+      url,
+      fields: fields.filter((f) => f.firstSeenMs === null)
+    }))
+    .filter((r) => r.fields.length > 0);
+
+const buildTable = (data = unseenOnly()) => {
+  const table = [];
+  for (const { url, fields } of data) {
+    for (const field of fields) {
+      table.push({
+        request: url,
+        field: field.path,
+        value: field.value,
+        seen: false
+      });
+    }
+  }
+  return table;
+};
+
 Cypress.on('window:before:load', (win) => {
   interceptResponses(win, (data, url) => {
     if (!recording || !shouldTrack(url)) return;
@@ -25,21 +48,20 @@ Cypress.Commands.add('startApiRecording', (options = {}) => {
 
 Cypress.Commands.add('stopApiRecording', () => {
   recording = false;
-  const table = [];
-  for (const { url, fields } of report) {
-    for (const field of fields) {
-      table.push({
-        request: url,
-        field: field.path,
-        value: field.value,
-        seen: field.firstSeenMs !== null
-      });
-    }
-  }
+  const unseen = unseenOnly();
+  const table = buildTable(unseen);
+  Cypress.log({ name: 'api-values', consoleProps: () => table });
   if (table.length) console.table(table);
-  return cy.wrap(report);
+  return cy.wrap(unseen);
 });
 
 Cypress.Commands.add('getApiReport', () => {
-  return cy.wrap(report);
+  return cy.wrap(unseenOnly());
 });
+
+export const getApiReportTask = (reportData = []) => {
+  const unseen = unseenOnly(reportData);
+  const table = buildTable(unseen);
+  if (table.length) console.table(table);
+  return unseen;
+};

--- a/cypress/e2e/api_recording.cy.js
+++ b/cypress/e2e/api_recording.cy.js
@@ -22,9 +22,7 @@ describe('API recording plugin', () => {
     cy.visit('/test-page');
     cy.wait('@api');
     cy.stopApiRecording().then(report => {
-      expect(report[0].fields[0])
-        .to.have.property('firstSeenMs')
-        .and.be.lt(500);
+      expect(report).to.be.empty;
     });
   });
 
@@ -42,6 +40,7 @@ describe('API recording plugin', () => {
     cy.wait('@api');
     cy.wait(600);
     cy.stopApiRecording().then(report => {
+      expect(report).to.have.length(1);
       const field = report[0].fields[0];
       expect(field).to.have.property('firstSeenMs', null);
       expect(field.lastCheckedMs).to.be.gte(500);

--- a/cypress/e2e/complex_demo.cy.js
+++ b/cypress/e2e/complex_demo.cy.js
@@ -1,0 +1,72 @@
+import '../../cypress-plugin';
+
+describe('complex API recording demo', () => {
+  it('handles nested data across pages and reports unseen values', () => {
+    cy.startApiRecording({ timeoutMs: 500 });
+
+    cy.intercept('/api/first', { body: { user: { name: 'Alice' }, shared: 'dup' } }).as('api1');
+    cy.intercept('/api/second', { body: { info: { deep: { value: 'two' }, label: 'dup' } } }).as('api2');
+    cy.intercept('/api/third', { body: { secret: 'hidden' } }).as('api3');
+
+    cy.intercept('/page-a', {
+      body: `<!DOCTYPE html><html><body>
+        <h1>First Page</h1><p>Lots of content here.</p>
+        <div id="content"></div>
+        <script>
+          fetch('/api/first').then(r => r.json()).then(d => {
+            document.getElementById('content').innerHTML =
+              '<div id="name">'+d.user.name+'</div>'+
+              '<div id="dup1">'+d.shared+'</div>';
+          });
+        </script>
+      </body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.intercept('/page-b', {
+      body: `<!DOCTYPE html><html><body>
+        <h1>Second Page</h1><p>More text...</p>
+        <div id="content"></div>
+        <script>
+          fetch('/api/second').then(r => r.json()).then(d => {
+            document.getElementById('content').innerHTML =
+              '<div id="deep">'+d.info.deep.value+'</div>'+
+              '<div id="dup2">'+d.info.label+'</div>';
+          });
+        </script>
+      </body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.intercept('/page-c', {
+      body: `<!DOCTYPE html><html><body>
+        <h1>Third Page</h1><p>This page doesn't show API data.</p>
+        <script>
+          fetch('/api/third').then(r => r.json()).then(() => {});
+        </script>
+      </body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/page-a');
+    cy.wait('@api1');
+    cy.get('#name').should('have.text', 'Alice');
+    cy.get('#dup1').should('have.text', 'dup');
+
+    cy.visit('/page-b');
+    cy.wait('@api2');
+    cy.get('#deep').should('have.text', 'two');
+    cy.get('#dup2').should('have.text', 'dup');
+
+    cy.visit('/page-c');
+    cy.wait('@api3');
+
+    cy.stopApiRecording().then(report => {
+      expect(report).to.have.length(1);
+      const hidden = report[0];
+      expect(hidden.url).to.include('/api/third');
+      expect(hidden.fields[0].path).to.equal('secret');
+      expect(hidden.fields[0].firstSeenMs).to.be.null;
+    });
+  });
+});

--- a/cypress/e2e/multi_page.cy.js
+++ b/cypress/e2e/multi_page.cy.js
@@ -40,11 +40,7 @@ describe('API recording across pages', () => {
     cy.get('#beta').should('have.text', 'two');
 
     cy.stopApiRecording().then((report) => {
-      expect(report).to.have.length(2);
-      const first = report.find(r => r.url.includes('/api/first'));
-      const second = report.find(r => r.url.includes('/api/second'));
-      expect(first.fields[0].firstSeenMs).to.be.a('number');
-      expect(second.fields[0].firstSeenMs).to.be.a('number');
+      expect(report).to.be.empty;
     });
   });
 });


### PR DESCRIPTION
## Summary
- Filter API reporting to only include values that never appear in the DOM
- Add complex multi-page Cypress demo with nested responses and hidden values
- Update docs and tests for unseen-only API reporting

## Testing
- `npm test`
- `npx cypress run` *(fails: Need to install the following packages: cypress@15.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a730bfc9c88320988586a987a3a19a