### PR TITLE
Handle pending API observers when stopping recording

### DIFF
--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -4,6 +4,7 @@ let recording = false;
 let domains = [];
 let report = [];
 let timeoutMs = 5000;
+let finalizers = [];
 
 const shouldTrack = (url) =>
   domains.length === 0 || domains.some((d) => url.includes(d));
@@ -35,7 +36,14 @@ Cypress.on('window:before:load', (win) => {
   interceptResponses(win, (data, url) => {
     if (!recording || !shouldTrack(url)) return;
     const fields = collectFields(data);
-    observeFields(win, fields, url, (result) => report.push(result), timeoutMs);
+    const finalize = observeFields(
+      win,
+      fields,
+      url,
+      (result) => report.push(result),
+      timeoutMs
+    );
+    finalizers.push(finalize);
   });
 });
 
@@ -44,10 +52,12 @@ Cypress.Commands.add('startApiRecording', (options = {}) => {
   timeoutMs = options.timeoutMs || 5000;
   report = [];
   recording = true;
+  finalizers = [];
 });
 
 Cypress.Commands.add('stopApiRecording', () => {
   recording = false;
+  finalizers.forEach((fn) => fn());
   const unseen = unseenOnly();
   const table = buildTable(unseen);
   Cypress.log({ name: 'api-values', consoleProps: () => table });

--- a/shared/apiValueTracker.js
+++ b/shared/apiValueTracker.js
@@ -86,13 +86,15 @@ export function observeFields(win, fields, url, log, timeoutMs = 5000) {
     if (finished) return;
     finished = true;
     win.clearTimeout(timeoutId);
+    const elapsed = win.performance.now() - start;
     for (const field of fields) {
       if (field.firstSeenMs === null) {
-        field.lastCheckedMs = Math.max(field.lastCheckedMs, timeoutMs);
+        field.lastCheckedMs = Math.max(field.lastCheckedMs, elapsed);
       }
     }
     log({ url, fields });
   }
 
   check();
+  return finalize;
 }


### PR DESCRIPTION
## Summary
- finalize any active API field observers when recording stops
- track finalizers for each observed API call
- ensure field observers record last checked timestamp when finalized

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74e2c7024832083c930034658511e