### PR TITLE
Add advanced API path filtering and delay threshold to Cypress plugin

### DIFF
--- a/cypress/e2e/advanced_options.cy.js
+++ b/cypress/e2e/advanced_options.cy.js
@@ -1,0 +1,50 @@
+import '../../cypress-plugin';
+
+describe('API recording advanced options', () => {
+  it('ignores and expects paths while enforcing delay threshold', () => {
+    cy.startApiRecording({
+      timeoutMs: 500,
+      thresholdMs: 200,
+      excludePaths: ['/api/ignore.secret'],
+      expectAbsentPaths: ['/api/secret.token']
+    });
+
+    cy.intercept('/api/ignore', { body: { secret: 'nope' } }).as('ignore');
+    cy.intercept('/api/slow', { body: { slow: 'delayed' } }).as('slowApi');
+    cy.intercept('/api/secret', { body: { token: 'shh' } }).as('secret');
+
+    cy.intercept('/demo', {
+      body: `<!DOCTYPE html><html><body>
+        <script>
+          fetch('/api/ignore').then(r => r.json()).then(() => {});
+          fetch('/api/slow').then(r => r.json()).then(d => {
+            setTimeout(() => {
+              const el = document.createElement('div');
+              el.id = 'slow';
+              el.textContent = d.slow;
+              document.body.appendChild(el);
+            }, 300);
+          });
+          fetch('/api/secret').then(r => r.json()).then(() => {});
+        </script>
+      </body></html>`,
+      headers: { 'content-type': 'text/html' }
+    });
+
+    cy.visit('/demo');
+    cy.wait('@ignore');
+    cy.wait('@slowApi');
+    cy.wait('@secret');
+
+    cy.get('#slow').should('have.text', 'delayed');
+
+    cy.stopApiRecording().then((report) => {
+      expect(report).to.have.length(1);
+      const field = report[0].fields[0];
+      expect(field.apiPath).to.equal('/api/slow.slow');
+      expect(field.firstSeenMs).to.be.greaterThan(200);
+      // Fails the test if any other missing values exist
+      expect(report, 'Only slow field should be reported').to.have.length(1);
+    });
+  });
+});

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -135,14 +135,16 @@ test('reports unseen values when they never appear', { concurrency: false }, asy
       field: 'missing.deeper.secret',
       apiPath: 'https://example.com/api.missing.deeper.secret',
       value: 'value',
-      seen: false
+      seen: false,
+      firstSeenMs: null
     },
     {
       request: 'https://example.com/api',
       field: 'missing.deeper.other',
       apiPath: 'https://example.com/api.missing.deeper.other',
       value: 'alt',
-      seen: false
+      seen: false,
+      firstSeenMs: null
     }
   ];
   assert.deepEqual(tables[0], expectedTable);
@@ -172,7 +174,8 @@ test('ignores fetches to disallowed domains', { concurrency: false }, async () =
       field: 'foo',
       apiPath: 'https://allowed.com/api.foo',
       value: 'bar',
-      seen: false
+      seen: false,
+      firstSeenMs: null
     }
   ];
   assert.deepEqual(tables[0], expectedTable);


### PR DESCRIPTION
## Summary
- support ignoring and expecting API paths plus delay threshold in `startApiRecording`
- include first-seen timing in reports and new console table column
- add Cypress e2e demonstrating exclusions, absence expectations, and threshold reporting

## Testing
- `npm test`
- `npx cypress run --spec cypress/e2e/advanced_options.cy.js`


------
https://chatgpt.com/codex/tasks/task_e_68b052ff08b88320b0526cadb9a7d23c