### PR TITLE
Use cy.intercept for API tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    });
    ```
 
-The plugin tracks `fetch` and `XMLHttpRequest` calls across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds). Only unseen values are included in the final report and logs.
+The plugin uses `cy.intercept` to watch API requests across page loads and records how long it takes for each field value to appear in the DOM (up to the configured timeout, default five seconds). Only unseen values are included in the final report and logs.
 
 ## Development
 

--- a/firefox-extension/content.js
+++ b/firefox-extension/content.js
@@ -1,4 +1,38 @@
-import { interceptResponses, collectFields, observeFields } from '../shared/apiValueTracker.js';
+import { collectFields, observeFields } from '../shared/apiValueTracker.js';
+
+function interceptResponses(win, handler) {
+  const originalFetch = win.fetch;
+  win.fetch = async function (...args) {
+    const response = await originalFetch.apply(this, args);
+    try {
+      const clone = response.clone();
+      const data = await clone.json();
+      await handler(data, args[0]);
+    } catch (e) {
+      // non JSON response
+    }
+    return response;
+  };
+
+  const originalOpen = win.XMLHttpRequest.prototype.open;
+  win.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+    this._url = url;
+    return originalOpen.call(this, method, url, ...rest);
+  };
+
+  const originalSend = win.XMLHttpRequest.prototype.send;
+  win.XMLHttpRequest.prototype.send = function (...sendArgs) {
+    this.addEventListener('load', function () {
+      try {
+        const data = JSON.parse(this.responseText);
+        handler(data, this._url);
+      } catch (e) {
+        // ignore non JSON
+      }
+    });
+    return originalSend.apply(this, sendArgs);
+  };
+}
 
 (() => {
   const runtime = typeof browser !== 'undefined' ? browser.runtime : chrome.runtime;

--- a/shared/apiValueTracker.js
+++ b/shared/apiValueTracker.js
@@ -1,37 +1,3 @@
-export function interceptResponses(win, handler) {
-  const originalFetch = win.fetch;
-  win.fetch = async function (...args) {
-    const response = await originalFetch.apply(this, args);
-    try {
-      const clone = response.clone();
-      const data = await clone.json();
-      await handler(data, args[0]);
-    } catch (e) {
-      // non JSON response
-    }
-    return response;
-  };
-
-  const originalOpen = win.XMLHttpRequest.prototype.open;
-  win.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
-    this._url = url;
-    return originalOpen.call(this, method, url, ...rest);
-  };
-
-  const originalSend = win.XMLHttpRequest.prototype.send;
-  win.XMLHttpRequest.prototype.send = function (...sendArgs) {
-    this.addEventListener('load', function () {
-      try {
-        const data = JSON.parse(this.responseText);
-        handler(data, this._url);
-      } catch (e) {
-        // ignore non JSON
-      }
-    });
-    return originalSend.apply(this, sendArgs);
-  };
-}
-
 export function collectFields(data, path = [], fields = []) {
   if (data && typeof data === 'object') {
     for (const key in data) {


### PR DESCRIPTION
## Summary
- replace custom fetch/XMLHttpRequest patching with `cy.intercept('**')`
- drop shared `interceptResponses` helper and keep only field/DOM utilities
- document the new interception approach and update tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83a3b63708320898c217a9bfd0279