### PR TITLE
Refactor API recording intercept

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    cy.startApiRecording({ domains: ['api.example.com'], timeoutMs: 5000 });
    ```
 
+   `startApiRecording` attaches an internal `cy.intercept` listener for the
+   duration of your test. Define any other `cy.intercept` stubs first, then
+   call it before triggering requests you want to monitor.
+
 3. Run your test actions. When finished, stop recording and save the report:
 
    ```js
@@ -40,9 +44,9 @@ A Firefox extension and Cypress plugin that intercept API requests, records fiel
    });
   ```
 
-   `stopApiRecording` logs a table of any API field values that never
-   appeared in the DOM. When running `cypress run`, you can register a task
-   to print the same table from the Node process:
+   `stopApiRecording` tears down the intercept and logs a table of any API
+   field values that never appeared in the DOM. When running `cypress run`,
+   you can register a task to print the same table from the Node process:
 
    ```js
    // cypress.config.js

--- a/cypress-plugin/index.js
+++ b/cypress-plugin/index.js
@@ -9,6 +9,7 @@ let thresholdMs = Infinity;
 let excludePaths = [];
 let expectAbsentPaths = [];
 let currentWin;
+let interceptor;
 
 const shouldTrack = (url) =>
   domains.length === 0 || domains.some((d) => url.includes(d));
@@ -51,10 +52,14 @@ Cypress.on('window:before:load', (win) => {
   currentWin = win;
 });
 
-cy.intercept('**', (req) => {
-  req.continue((res) => {
-    const url = req.url;
-    if (!recording || !currentWin || !shouldTrack(url)) return;
+const interceptHandler = (req) => {
+  req.on('after:response', (res) => {
+    const fullUrl = req.url;
+    if (!recording || !currentWin || !shouldTrack(fullUrl)) return;
+    let url = fullUrl;
+    try {
+      url = new URL(fullUrl).pathname;
+    } catch {}
     const ct = res.headers && (res.headers['content-type'] || res.headers['Content-Type'] || '');
     if (!ct.includes('application/json')) return;
     let data = res.body;
@@ -75,7 +80,7 @@ cy.intercept('**', (req) => {
     );
     finalizers.push(finalize);
   });
-});
+};
 
 Cypress.Commands.add('startApiRecording', (options = {}) => {
   domains = (options.domains || []).map((d) => d.trim()).filter(Boolean);
@@ -86,11 +91,18 @@ Cypress.Commands.add('startApiRecording', (options = {}) => {
   report = [];
   recording = true;
   finalizers = [];
+  return cy.intercept({ url: '**', middleware: true }, interceptHandler).then((i) => {
+    interceptor = i;
+  });
 });
 
 Cypress.Commands.add('stopApiRecording', () => {
   recording = false;
   finalizers.forEach((fn) => fn());
+  if (interceptor) {
+    interceptor.restore();
+    interceptor = null;
+  }
   const unseen = unseenOnly();
   const table = buildTable(unseen);
   Cypress.log({ name: 'api-values', consoleProps: () => table });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -5,6 +5,7 @@ import { performance } from 'node:perf_hooks';
 const commands = {};
 let windowHandler;
 let interceptHandler;
+let restoreCount = 0;
 const tables = [];
 const logs = [];
 
@@ -32,6 +33,15 @@ global.cy = {
   wrap: (x) => x,
   intercept: (_matcher, handler) => {
     interceptHandler = handler;
+    const interceptor = {
+      restore: () => {
+        interceptHandler = null;
+        restoreCount++;
+      }
+    };
+    return {
+      then: (fn) => fn(interceptor)
+    };
   }
 };
 
@@ -60,15 +70,19 @@ function createWin(responseData) {
     clearTimeout,
     async fetch(url) {
       if (interceptHandler) {
-        await interceptHandler({
+        const events = {};
+        interceptHandler({
           url,
-          continue: async (fn) => {
-            await fn({
-              headers: { 'content-type': 'application/json' },
-              body: responseData
-            });
+          on: (event, cb) => {
+            events[event] = cb;
           }
         });
+        if (events['after:response']) {
+          await events['after:response']({
+            headers: { 'content-type': 'application/json' },
+            body: responseData
+          });
+        }
       }
       return new ResponseStub(responseData);
     },
@@ -150,17 +164,17 @@ test('reports unseen values when they never appear', { concurrency: false }, asy
   assert.ok(field2.lastCheckedMs < 100);
   const expectedTable = [
     {
-      request: 'https://example.com/api',
+      request: '/api',
       field: 'missing.deeper.secret',
-      apiPath: 'https://example.com/api.missing.deeper.secret',
+      apiPath: '/api.missing.deeper.secret',
       value: 'value',
       seen: false,
       firstSeenMs: null
     },
     {
-      request: 'https://example.com/api',
+      request: '/api',
       field: 'missing.deeper.other',
-      apiPath: 'https://example.com/api.missing.deeper.other',
+      apiPath: '/api.missing.deeper.other',
       value: 'alt',
       seen: false,
       firstSeenMs: null
@@ -186,12 +200,12 @@ test('ignores fetches to disallowed domains', { concurrency: false }, async () =
   logs.length = 0;
   const report = commands.stopApiRecording();
   assert.equal(report.length, 1);
-  assert.equal(report[0].url, 'https://allowed.com/api');
+  assert.equal(report[0].url, '/api');
   const expectedTable = [
     {
-      request: 'https://allowed.com/api',
+      request: '/api',
       field: 'foo',
-      apiPath: 'https://allowed.com/api.foo',
+      apiPath: '/api.foo',
       value: 'bar',
       seen: false,
       firstSeenMs: null
@@ -200,4 +214,17 @@ test('ignores fetches to disallowed domains', { concurrency: false }, async () =
   assert.deepEqual(tables[0], expectedTable);
   assert.equal(logs[0].name, 'api-values');
   assert.deepEqual(logs[0].consoleProps(), expectedTable);
+});
+
+test('tears down intercept after stopping', { concurrency: false }, async () => {
+  const win = createWin({ foo: 'bar' });
+  windowHandler(win);
+
+  restoreCount = 0;
+  commands.startApiRecording({ timeoutMs: 30 });
+  await win.fetch('https://example.com/api');
+  commands.stopApiRecording();
+
+  assert.equal(interceptHandler, null);
+  assert.equal(restoreCount, 1);
 });


### PR DESCRIPTION
## Summary
- move cy.intercept setup into `startApiRecording` and tear it down in `stopApiRecording`
- document new scoped intercept behavior and advise calling setup after defining other stubs
- update tests for path-based URLs and ensure intercept restoration

## Testing
- `npm test`
- `npx cypress run`

------
https://chatgpt.com/codex/tasks/task_e_68bacf62f0f08320a793430ab0cdaaee